### PR TITLE
Updated the minimum macOS version required

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MultipeerKit",
     platforms: [
-        .macOS(.v10_14),
+        .macOS(.v10_15),
         .iOS(.v12),
         .tvOS(.v12)
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MultipeerKit",
     platforms: [
-        .macOS(.v10_15),
+        .macOS(.v10_14),
         .iOS(.v12),
         .tvOS(.v12)
     ],

--- a/Sources/MultipeerKit/Public API/MultipeerDataSource.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerDataSource.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(OSX 10.15, *)
 @available(iOS 13.0, *)
 /// This class can be used to monitor nearby peers in a reactive way,
 /// it's especially useful for SwiftUI apps.


### PR DESCRIPTION
MultipeerDataSource conformance to ObservableObject and the property wrapper @Published requires macOS 10.15.
I've also downgraded the swift tools version to work with latest stable release of Xcode.