### PR TITLE
Enabling the use of MultipeerKit on tvOS

### DIFF
--- a/Sources/MultipeerKit/Public API/MultipeerDataSource.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerDataSource.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(tvOS 13.0, *)
 @available(OSX 10.15, *)
 @available(iOS 13.0, *)
 /// This class can be used to monitor nearby peers in a reactive way,


### PR DESCRIPTION
MultipeerKit compiles and works on tvOS, so I add this to enable the use of MultipeerKit on tvOS. We also need to change the example app to work on tvOS. I can do the required changes if you agree with this.