### PR TITLE
Peer connection bug fix

### DIFF
--- a/Sources/MultipeerKit/Internal API/MultipeerConnection.swift
+++ b/Sources/MultipeerKit/Internal API/MultipeerConnection.swift
@@ -218,7 +218,7 @@ extension MultipeerConnection: MCNearbyServiceAdvertiserDelegate {
         guard let peer = discoveredPeers[peerID] else { return }
 
         configuration.security.invitationHandler(peer, context, { decision in
-            invitationHandler(decision, decision ? session : nil)
+            invitationHandler(decision, decision ? self.session : nil)
         })
     }
 

--- a/Sources/MultipeerKit/Internal API/MultipeerConnection.swift
+++ b/Sources/MultipeerKit/Internal API/MultipeerConnection.swift
@@ -120,17 +120,15 @@ extension MultipeerConnection: MCSessionDelegate {
 
         let handler = invitationCompletionHandlers[peerID]
 
-        defer { invitationCompletionHandlers[peerID] = nil }
-
         DispatchQueue.main.async {
             switch state {
             case .connected:
                 handler?(.success(peer))
-
+                self.invitationCompletionHandlers[peerID] = nil
                 self.didConnectToPeer?(peer)
             case .notConnected:
                 handler?(.failure(MultipeerError(localizedDescription: "Failed to connect to peer.")))
-
+                self.invitationCompletionHandlers[peerID] = nil
                 self.didDisconnectFromPeer?(peer)
             case .connecting:
                 break

--- a/Sources/MultipeerKit/Public API/MultipeerConfiguration.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerConfiguration.swift
@@ -20,7 +20,7 @@ public struct MultipeerConfiguration {
     /// Configures security-related aspects of the multipeer connection.
     public struct Security {
 
-        public typealias InvitationHandler = (Peer, Data?, (Bool) -> Void) -> Void
+        public typealias InvitationHandler = (Peer, Data?, @escaping (Bool) -> Void) -> Void
 
         /// An array of information that can be used to identify the peer to other nearby peers.
         ///

--- a/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
@@ -151,7 +151,7 @@ public final class MultipeerTransceiver {
     }
 
     private func handlePeerRemoved(_ peer: Peer) {
-        guard let idx = availablePeers.firstIndex(of: peer) else { return }
+        guard let idx = availablePeers.firstIndex(where: { $0.underlyingPeer == peer.underlyingPeer }) else { return }
 
         availablePeers.remove(at: idx)
     }
@@ -165,7 +165,7 @@ public final class MultipeerTransceiver {
     }
 
     private func setConnected(_ connected: Bool, on peer: Peer) {
-        guard let idx = availablePeers.firstIndex(of: peer) else { return }
+        guard let idx = availablePeers.firstIndex(where: { $0.underlyingPeer == peer.underlyingPeer }) else { return }
 
         var mutablePeer = availablePeers[idx]
         mutablePeer.isConnected = connected


### PR DESCRIPTION
There seem to be a few bugs with how `MultipeerKit` handles manual invitations. This PR attempts to fix these issues, which include: 

- `MultipeerConnection` incorrectly sets a peer's completion handler in `invitationCompletionHandlers` to `nil` before calling it. From what I can tell, the `connecting` state occurs first, resulting in the handler being set to `nil`.

- `MultipeerTransceiver` isn't able to correctly get the `Peer` from `availablePeers` upon connection and removal. It's currently searching in `availablePeers` for the index that matches the `Peer` being passed in, but this equality seems to be always `false` since the argument's `isConnected` property doesn't match with the property stored in `availablePeers`. I modified the index search to instead compare `underlyingPeer`.

- ~`InvitationHandler` should have an escaping closure to allow for instances where it needs to be escaping. For example, it needs to be escaping if the device being connected to wants to display a popup asking for permission.~

Hopefully these fixes make sense, but I'm happy to help clarify anything if needed :)