### PR TITLE
Add dynamic library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
         .library(
             name: "MultipeerKit",
             targets: ["MultipeerKit"]),
+        .library(
+            name: "MultipeerKit-dynamic",
+            type: .dynamic,
+            targets: ["MultipeerKit"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.


### PR DESCRIPTION
This fixes an issue using the library in an app with frameworks in Xcode 11.4 (which has some [known issues](https://github.com/renaudjenny/Swift-Package-Manager-Static-Dynamic-Xcode-Bug) with this):

```
error: Swift package product 'MultipeerKit' is linked as a static library by 'Arena' and 'HistoryTransceiver'. This will result in duplication of library code.
```

Now it's possible to select the `-dynamic` library variant to work around this.

Changing the main target to `.dynamic` would also work of course but I believe that poses issues with command line tools that need/want static linking, so changing to `.dynamic` isn't a universal fix.