### PR TITLE
peerAdded and peerRemoved closures added

### DIFF
--- a/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
@@ -12,8 +12,14 @@ public final class MultipeerTransceiver {
     /// Called on the main queue when available peers have changed (new peers discovered or peers removed).
     public var availablePeersDidChange: ([Peer]) -> Void = { _ in }
 
+    /// Called on the main queue when a new peer discovered.
+    public var peerAdded: (Peer) -> Void = { _ in }
+
+    /// Called on the main queue when a peer removed.
+    public var peerRemoved: (Peer) -> Void = { _ in }
+
     /// All peers currently available for invitation, connection and data transmission.
-    public var availablePeers: [Peer] = [] {
+    public private(set) var availablePeers: [Peer] = [] {
         didSet {
             guard availablePeers != oldValue else { return }
 
@@ -148,12 +154,14 @@ public final class MultipeerTransceiver {
         guard !availablePeers.contains(peer) else { return }
 
         availablePeers.append(peer)
+        peerAdded(peer)
     }
 
     private func handlePeerRemoved(_ peer: Peer) {
         guard let idx = availablePeers.firstIndex(where: { $0.underlyingPeer == peer.underlyingPeer }) else { return }
 
         availablePeers.remove(at: idx)
+        peerRemoved(peer)
     }
 
     private func handlePeerConnected(_ peer: Peer) {


### PR DESCRIPTION
Hey Guilherme and thanks for a great and easy to use wrapper!
For my project I wanted to be notified only when peers were added or removed without keeping reference to the actual peers array. So I've added few more closures just for this purpose. If you think it might be useful feel free to review otherwise just close it. :)

Actually ideal would be `CollectionDifference` solution here but it's available only in latests OS :(