### PR TITLE
Added callbacks for peer connection and disconnection

### DIFF
--- a/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
@@ -18,6 +18,12 @@ public final class MultipeerTransceiver {
     /// Called on the main queue when a peer removed.
     public var peerRemoved: (Peer) -> Void = { _ in }
 
+    /// Called on the main queue when a connection is established with a peer.
+    public var peerConnected: (Peer) -> Void = { _ in }
+    
+    /// Called on the main queue when the connection with a peer is interrupted.
+    public var peerDisconnected: (Peer) -> Void = { _ in }
+    
     /// The current device's peer id
     public var localPeerId: String? {
         return connection.getLocalPeerId()
@@ -174,10 +180,14 @@ public final class MultipeerTransceiver {
 
     private func handlePeerConnected(_ peer: Peer) {
         setConnected(true, on: peer)
+        
+        peerConnected(peer)
     }
 
     private func handlePeerDisconnected(_ peer: Peer) {
         setConnected(false, on: peer)
+        
+        peerDisconnected(peer)
     }
 
     private func setConnected(_ connected: Bool, on peer: Peer) {


### PR DESCRIPTION
This introduces two new callbacks as public API: `peerConnected` and `peerDisconnected`, which are called when a remote peer connects to the local peer and when a remote peer disconnects from the local peer.