### PR TITLE
move to Peer for localPeer

### DIFF
--- a/Sources/MultipeerKit/Internal API/MockMultipeerConnection.swift
+++ b/Sources/MultipeerKit/Internal API/MockMultipeerConnection.swift
@@ -36,8 +36,8 @@ final class MockMultipeerConnection: MultipeerProtocol {
         
     }
     
-    func getLocalPeerId() -> String? {
-        return localPeer.id
+    func getLocalPeer() -> Peer? {
+        return localPeer
     }
 
 }

--- a/Sources/MultipeerKit/Internal API/MultipeerConnection.swift
+++ b/Sources/MultipeerKit/Internal API/MultipeerConnection.swift
@@ -117,8 +117,8 @@ final class MultipeerConnection: NSObject, MultipeerProtocol {
         browser.invitePeer(peer.underlyingPeer, to: session, withContext: context, timeout: timeout)
     }
     
-    func getLocalPeerId() -> String? {
-        return try? Peer(peer: me, discoveryInfo: nil).id
+    func getLocalPeer() -> Peer? {
+        return try? Peer(peer: me, discoveryInfo: nil)
     }
 
 }

--- a/Sources/MultipeerKit/Internal API/MultipeerProtocol.swift
+++ b/Sources/MultipeerKit/Internal API/MultipeerProtocol.swift
@@ -17,6 +17,6 @@ protocol MultipeerProtocol: AnyObject {
     func broadcast(_ data: Data) throws
     func send(_ data: Data, to peers: [Peer]) throws
     
-    func getLocalPeerId() -> String?
+    func getLocalPeer() -> Peer?
 
 }

--- a/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
@@ -25,8 +25,8 @@ public final class MultipeerTransceiver {
     public var peerDisconnected: (Peer) -> Void = { _ in }
     
     /// The current device's peer id
-    public var localPeerId: String? {
-        return connection.getLocalPeerId()
+    public var localPeer: Peer? {
+        return connection.getLocalPeer()
     }
     
     /// All peers currently available for invitation, connection and data transmission.

--- a/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
+++ b/Sources/MultipeerKit/Public API/MultipeerTransceiver.swift
@@ -28,7 +28,12 @@ public final class MultipeerTransceiver {
     public var localPeer: Peer? {
         return connection.getLocalPeer()
     }
-    
+
+    @available(*, deprecated, message: "If you need the String Id, you can get it from localPeer.id instead.")
+    public var localPeerId: String? {
+        return localPeer?.id
+    }
+
     /// All peers currently available for invitation, connection and data transmission.
     public private(set) var availablePeers: [Peer] = [] {
         didSet {

--- a/Tests/MultipeerKitTests/MultipeerKitTests.swift
+++ b/Tests/MultipeerKitTests/MultipeerKitTests.swift
@@ -38,7 +38,7 @@ final class MultipeerKitTests: XCTestCase {
 
         mock.receive(TestPayload.self) { payload, sender in
             XCTAssertEqual(payload, tsPayload)
-            XCTAssertEqual(sender.id, mock.localPeerId!)
+            XCTAssertEqual(sender.id, mock.localPeer!.id)
 
             expect.fulfill()
         }

--- a/Tests/MultipeerKitTests/MultipeerKitTests.swift
+++ b/Tests/MultipeerKitTests/MultipeerKitTests.swift
@@ -39,6 +39,7 @@ final class MultipeerKitTests: XCTestCase {
         mock.receive(TestPayload.self) { payload, sender in
             XCTAssertEqual(payload, tsPayload)
             XCTAssertEqual(sender.id, mock.localPeer!.id)
+            XCTAssertEqual(sender.id, mock.localPeerId!)
 
             expect.fulfill()
         }


### PR DESCRIPTION
I was wondering why most properties and methods use the `Peer` type while only `localPeerId` was String based.

This PR moves to `localPeer: Peer?` instead, which keeps the internal implementation (via `me`) hidden from the public API.

- properties updated
- tests pass